### PR TITLE
Fix broken link to immer introduction page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ you can inspect the React state and see it updated as changes happen.
 For additional samples, see [gojs-react-samples](https://github.com/NorthwoodsSoftware/gojs-react-samples).
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-It also uses [immer](https://immerjs.github.io/immer/docs/introduction) to simplify state update operations.
+It also uses [immer](https://immerjs.github.io/immer/) to simplify state update operations.
 
 ## Installation
 


### PR DESCRIPTION
I found the link is outdated.
It was updated at immerjs/immer#746 .